### PR TITLE
Remove Client.port/1 and rely on URI.parse for port detection

### DIFF
--- a/lib/off_broadway_websocket/client.ex
+++ b/lib/off_broadway_websocket/client.ex
@@ -32,14 +32,14 @@ defmodule OffBroadwayWebSocket.Client do
           list()
         ) :: {:ok, map()} | {:error, term()}
   def connect(url, path, gun_opts, await_timeout, connect_timeout, headers \\ []) do
-    %URI{host: host, port: _port, scheme: scheme} = URI.parse(url)
+    %URI{host: host, port: port, scheme: scheme} = URI.parse(url)
 
     host = host || url
     scheme = scheme || "wss"
 
     opts = connect_opts(host, scheme, connect_timeout, gun_opts)
 
-    with {:ok, conn_pid} <- :gun.open(String.to_charlist(host), port(scheme), opts),
+    with {:ok, conn_pid} <- :gun.open(String.to_charlist(host), port, opts),
          {:ok, _protocol} <- :gun.await_up(conn_pid, await_timeout),
          stream_ref <- :gun.ws_upgrade(conn_pid, path, headers) do
       {:ok, %{conn_pid: conn_pid, stream_ref: stream_ref}}
@@ -80,10 +80,4 @@ defmodule OffBroadwayWebSocket.Client do
   @spec transport(String.t()) :: atom()
   def transport("wss"), do: :tls
   def transport(_), do: :tcp
-
-  @doc false
-  @spec port(String.t()) :: non_neg_integer()
-  def port("wss"), do: 443
-  def port("ws"), do: 80
-  def port(_), do: 443
 end

--- a/test/off_broadway_websocket/client_test.exs
+++ b/test/off_broadway_websocket/client_test.exs
@@ -79,20 +79,6 @@ defmodule OffBroadwayWebSocket.ClientTest do
     end
   end
 
-  describe "port/1" do
-    test "returns port no 443 when using secure websocket" do
-      assert 443 == Client.port("wss")
-    end
-
-    test "returns port no 80 when not using secure websocket" do
-      assert 80 == Client.port("ws")
-    end
-
-    test "defaults to port no 443 when passed unrecognized protocol" do
-      assert 443 == Client.port("http")
-    end
-  end
-
   describe "connect_opts/4" do
     test "builds opts with given host, scheme, and timeout" do
       host = "example.com"


### PR DESCRIPTION
Hey there, thanks for the library 😄 

I would like to suggest a change that would allow connecting to local servers bound to custom ports (80 is not always available for local development). Current code fails by forcing port 80 or 443.

I think the code should rely on `URI.parse/1` for port detection, as it seems pretty accurate:
```
iex(1)> URI.parse "ws://localhost:4001"
%URI{
  scheme: "ws",
  authority: "localhost:4001",
  userinfo: nil,
  host: "localhost",
  port: 4001,
  path: nil,
  query: nil,
  fragment: nil
}
iex(2)> URI.parse "wss://localhost:4001"
%URI{
  scheme: "wss",
  authority: "localhost:4001",
  userinfo: nil,
  host: "localhost",
  port: 4001,
  path: nil,
  query: nil,
  fragment: nil
}
iex(3)> URI.parse "wss://localhost"
%URI{
  scheme: "wss",
  authority: "localhost",
  userinfo: nil,
  host: "localhost",
  port: 443,
  path: nil,
  query: nil,
  fragment: nil
}
iex(4)> URI.parse "ws://localhost"
%URI{
  scheme: "ws",
  authority: "localhost",
  userinfo: nil,
  host: "localhost",
  port: 80,
  path: nil,
  query: nil,
  fragment: nil
}
iex(5)> URI.parse "http://localhost"
%URI{
  scheme: "http",
  authority: "localhost",
  userinfo: nil,
  host: "localhost",
  port: 80,
  path: nil,
  query: nil,
  fragment: nil
}
```