### PR TITLE
Fix map keys assertion order in state test

### DIFF
--- a/test/off_broadway_websocket/state_test.exs
+++ b/test/off_broadway_websocket/state_test.exs
@@ -76,7 +76,7 @@ defmodule OffBroadwayWebSocket.StateTest do
 
       assert is_map(opts)
 
-      assert Map.keys(opts)    == [:delay, :retries_left, :max_retries]
+      assert Enum.sort(Map.keys(opts)) == [:delay, :max_retries, :retries_left]
       assert opts.max_retries  == 5
       assert opts.retries_left == 5
       assert opts.delay        == 10_000


### PR DESCRIPTION
## Summary
- ensure `Map.keys/1` assertion sorts keys before comparison

## Testing
- `mix test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f531173408332a1d7317b95ee895d