### PR TITLE
Improve type specifications

### DIFF
--- a/lib/off_broadway_websocket/client.ex
+++ b/lib/off_broadway_websocket/client.ex
@@ -22,12 +22,13 @@ defmodule OffBroadwayWebSocket.Client do
     - **{:error, reason}** if the connection or upgrade fails.
   """
   @spec connect(
-          String.t(),
-          String.t(),
-          map(),
-          non_neg_integer(),
-          list()
-        ) :: {:ok, map()} | {:error, term()}
+          url :: String.t(),
+          path :: String.t(),
+          gun_opts :: map(),
+          await_timeout :: non_neg_integer(),
+          headers :: [{String.t(), String.t()}]
+        ) ::
+        {:ok, %{conn_pid: pid(), stream_ref: reference()}} | {:error, term()}
   def connect(url, path, gun_opts, await_timeout, headers \\ []) do
     %URI{host: host, port: port, scheme: _scheme} = URI.parse(url)
 

--- a/lib/off_broadway_websocket/client_behaviour.ex
+++ b/lib/off_broadway_websocket/client_behaviour.ex
@@ -6,6 +6,7 @@ defmodule OffBroadwayWebSocket.ClientBehaviour do
               path          :: String.t(),
               gun_opts      :: map(),
               await_timeout :: non_neg_integer(),
-              headers       :: list()
-            ) :: {:ok, map()} | {:error, any()}
+              headers       :: [{String.t(), String.t()}]
+            ) ::
+            {:ok, %{conn_pid: pid(), stream_ref: reference()}} | {:error, term()}
 end

--- a/lib/off_broadway_websocket/producer.ex
+++ b/lib/off_broadway_websocket/producer.ex
@@ -132,7 +132,9 @@ defmodule OffBroadwayWebSocket.Producer do
   end
 
   @spec do_connect(State.t()) ::
-          {:ok, State.t()} | {:retry, non_neg_integer(), State.t()} | {:error, any()}
+          {:ok, State.t()}
+          | {:retry, non_neg_integer(), State.t()}
+          | {:error, :max_retries_exhausted | term()}
   defp do_connect(%State{ws_retry_opts: %{retries_left: 0}}) do
     Logger.warning("[#{@me}] retries exhausted")
     {:error, :max_retries_exhausted}

--- a/lib/off_broadway_websocket/utils.ex
+++ b/lib/off_broadway_websocket/utils.ex
@@ -23,8 +23,11 @@ defmodule OffBroadwayWebSocket.Utils do
     - **items** is the list of removed items.
     - **new_queue** is the remaining queue after removal.
   """
-  @spec pop_items(:queue.queue(), non_neg_integer(), non_neg_integer()) ::
-          {non_neg_integer(), list(), :queue.queue()}
+  @spec pop_items(
+          :queue.queue(term()),
+          non_neg_integer(),
+          non_neg_integer()
+        ) :: {non_neg_integer(), [term()], :queue.queue(term())}
   def pop_items(queue, 0, _), do: {0, [], queue}
   def pop_items(queue, _, 0), do: {0, [], queue}
   def pop_items(queue, m, n) when n > m, do: {m, :queue.to_list(queue), :queue.new()}


### PR DESCRIPTION
## Summary
- refine callback spec for `ClientBehaviour.connect/5`
- clarify types for `Client.connect/5`
- constrain queue types in `Utils.pop_items/3`
- specify `Producer.do_connect/1` error atom

## Testing
- `mix test` *(fails: `mix` not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f5a9542508332a092e1f9b038a4a8