### PR TITLE
Fix: pass ws_opts to :gun.ws_upgrade/4

### DIFF
--- a/lib/off_broadway_websocket/client.ex
+++ b/lib/off_broadway_websocket/client.ex
@@ -42,7 +42,8 @@ defmodule OffBroadwayWebSocket.Client do
 
     with {:ok, conn_pid}  <- :gun.open(to_charlist(host), port, gun_opts),
          {:ok, _protocol} <- :gun.await_up(conn_pid, await_timeout) do
-      stream_ref = :gun.ws_upgrade(conn_pid, path, headers)
+      {ws_opts, _} = Map.pop(gun_opts, :ws_opts, %{})
+      stream_ref = :gun.ws_upgrade(conn_pid, path, headers, ws_opts)
       {:ok, %{conn_pid: conn_pid, stream_ref: stream_ref}}
     else
       {:error, reason} -> {:error, reason}

--- a/test/off_broadway_websocket/client_test.exs
+++ b/test/off_broadway_websocket/client_test.exs
@@ -38,10 +38,11 @@ defmodule OffBroadwayWebSocket.ClientTest do
         {:ok, :dummy_protocol}
       end)
 
-      :meck.expect(:gun, :ws_upgrade, fn conn_pid, upgrade_path, upgrade_headers ->
+      :meck.expect(:gun, :ws_upgrade, fn conn_pid, upgrade_path, upgrade_headers, upgrade_ws_opts ->
         assert conn_pid == :dummy_conn_pid
         assert upgrade_path == path
         assert upgrade_headers == headers
+        assert upgrade_ws_opts == %{}
         :dummy_stream_ref
       end)
 
@@ -139,6 +140,38 @@ defmodule OffBroadwayWebSocket.ClientTest do
 
       assert :meck.num_calls(:gun, :open, 1)
       assert :meck.num_calls(:gun, :await_up, 1)
+
+      :meck.unload(:gun)
+    end
+
+    test "passes ws_opts from gun_opts to gun.ws_upgrade" do
+      url = "wss://example.com"
+      path = "/v1/test-endpoint"
+      ws_opts = %{keepalive: 10_000, silence_pings: false}
+      gun_opts = %{ws_opts: ws_opts, transport: :tls}
+      await_timeout = 50
+      headers = []
+
+      :meck.new(:gun, [:non_strict])
+
+      :meck.expect(:gun, :open, fn _host, _port, _opts ->
+        {:ok, :dummy_conn_pid}
+      end)
+
+      :meck.expect(:gun, :await_up, fn _conn_pid, _timeout ->
+        {:ok, :dummy_protocol}
+      end)
+
+      :meck.expect(:gun, :ws_upgrade, fn conn_pid, upgrade_path, upgrade_headers, upgrade_ws_opts ->
+        assert conn_pid == :dummy_conn_pid
+        assert upgrade_path == path
+        assert upgrade_headers == headers
+        assert upgrade_ws_opts == ws_opts
+        :dummy_stream_ref
+      end)
+
+      assert {:ok, %{conn_pid: :dummy_conn_pid, stream_ref: :dummy_stream_ref}} =
+               Client.connect(url, path, gun_opts, await_timeout, headers)
 
       :meck.unload(:gun)
     end


### PR DESCRIPTION
## Summary

- `ws_opts` nested inside `gun_opts` is documented but was never forwarded to the WebSocket upgrade call
- Extract `ws_opts` from `gun_opts` and pass it explicitly via `:gun.ws_upgrade/4`
- Add test verifying `ws_opts` reaches the upgrade call

## Context

`:gun.ws_upgrade/3` does not inherit `ws_opts` from the connection opts passed to `:gun.open/3`. The 4-arity `:gun.ws_upgrade/4` must be used to pass WebSocket-specific options like `keepalive` and `silence_pings`.