### PR TITLE
Prepare 1.2.2 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project are documented in this file.
 
 The format is based on Keep a Changelog, and this project follows Semantic Versioning.
 
+## [1.2.2] - 2026-07-14
+
+### Changed
+
+- Fixed `gun_opts[:ws_opts]` handling so documented websocket upgrade options are forwarded via `:gun.ws_upgrade/4`.
+
+### Tests
+
+- Added coverage verifying `ws_opts` is passed through to the Gun websocket upgrade call.
+
 ## [1.2.1] - 2026-03-22
 
 ### Added

--- a/mix.exs
+++ b/mix.exs
@@ -1,6 +1,6 @@
 defmodule OffBroadwayWebsocket.MixProject do
   use Mix.Project
-  @version "1.2.1"
+  @version "1.2.2"
 
   def project do
     [


### PR DESCRIPTION
## Summary

- bump package version to `1.2.2`
- add changelog entry for the `ws_opts` websocket upgrade bugfix now on `main`

## Validation

- [x] I ran the relevant local checks
- [x] I updated documentation if needed

## Notes

- Verified with `mix test` in a clean worktree for the release branch contents.
